### PR TITLE
Added a trailing slash to the expected location header.

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -16,7 +16,7 @@ function getRoll20SessionCookie(username, password) {
         return reject(err)
       }
 
-      if (httpResponse.statusCode !== 303 || httpResponse.headers['location'] !== 'https://app.roll20.net/home') {
+      if (httpResponse.statusCode !== 303 || httpResponse.headers['location'] !== 'https://app.roll20.net/home/') {
         return reject(new Error('Invalid Roll20 credentials!'))
       }
 


### PR DESCRIPTION
This fixes an issue where even though credentials were correct the "Invalid credentials" error was thrown.